### PR TITLE
chore: Bump version to v1.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "elyze"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "elyze"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2024"
 homepage = "https://github.com/Elyze-Parser/elyze"
 repository = "https://github.com/Elyze-Parser/elyze"
-documentation = "https://docs.rs/elyze"
+documentation = "https://docs.rs/elyze/latest/elyze/"
 authors = [
     "Akanoa <dev@guern.eu>"
 ]


### PR DESCRIPTION
Fix the documentation link to point to the latest