### PR TITLE
Remove the Scanner::into_data

### DIFF
--- a/examples/scanner.rs
+++ b/examples/scanner.rs
@@ -1,0 +1,15 @@
+use elyze::scanner::Scanner;
+
+fn process(mut scanner: Scanner<'_, u8>) -> &[u8] {
+    // do something with the data
+    // then bump the scanner
+    scanner.bump_by(3);
+    // return the remaining
+    scanner.remaining()
+}
+
+fn main() {
+    let data = b"hello world";
+    let remaining = process(Scanner::new(data));
+    assert_eq!(remaining, b"lo world");
+}

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -87,15 +87,6 @@ impl<'a, T> Scanner<'a, T> {
         self.cursor.get_ref()
     }
 
-    /// Consume the scanner and return a slice of the remaining data.
-    ///
-    /// # Returns
-    ///
-    /// A slice of the remaining data.
-    pub fn into_data(self) -> &'a [T] {
-        &self.cursor.get_ref()[self.current_position()..]
-    }
-
     /// Return true if there are no more elements to scan, false otherwise.
     ///
     /// # Returns


### PR DESCRIPTION
The "Scanner::into_data" does the same thing than "Scanner::remaining" but with a useless consuming scanner behavior