### PR TITLE
Merge Match and MatchSize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "elyze"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elyze"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2024"
 homepage = "https://github.com/Elyze-Parser/elyze"
 repository = "https://github.com/Elyze-Parser/elyze"

--- a/examples/addition.rs
+++ b/examples/addition.rs
@@ -1,8 +1,8 @@
 use elyze::bytes::matchers::match_number;
 use elyze::bytes::token::Token;
 use elyze::errors::ParseResult;
-use elyze::matcher::{Match, MatchSize};
-use elyze::recognizer::{Recognizable, recognize_slice};
+use elyze::matcher::Match;
+use elyze::recognizer::{recognize_slice, Recognizable};
 use elyze::scanner::Scanner;
 use elyze::visitor::Visitor;
 
@@ -11,13 +11,10 @@ struct TokenNumber;
 
 /// Implement the `Match` trait for the token number.
 impl Match<u8> for TokenNumber {
-    fn matcher(&self, data: &[u8]) -> (bool, usize) {
+    fn is_matching(&self, data: &[u8]) -> (bool, usize) {
         match_number(data)
     }
-}
 
-/// Implement the `MatchSize` trait for the token number.
-impl MatchSize for TokenNumber {
     fn size(&self) -> usize {
         0
     }

--- a/examples/expression.rs
+++ b/examples/expression.rs
@@ -4,7 +4,7 @@ use elyze::bytes::matchers::match_pattern;
 use elyze::bytes::primitives::number::Number;
 use elyze::bytes::primitives::whitespace::OptionalWhitespaces;
 use elyze::errors::{ParseError, ParseResult};
-use elyze::matcher::{Match, MatchSize};
+use elyze::matcher::Match;
 use elyze::peek::peek;
 use elyze::recognizer::Recognizer;
 use elyze::scanner::Scanner;
@@ -90,15 +90,13 @@ enum BinaryOperator {
 }
 
 impl Match<u8> for BinaryOperator {
-    fn matcher(&self, data: &[u8]) -> (bool, usize) {
+    fn is_matching(&self, data: &[u8]) -> (bool, usize) {
         match self {
             BinaryOperator::Add => match_pattern(b"+", data),
             BinaryOperator::Mul => match_pattern(b"*", data),
         }
     }
-}
 
-impl MatchSize for BinaryOperator {
     fn size(&self) -> usize {
         match self {
             BinaryOperator::Add => 1,

--- a/examples/matcher.rs
+++ b/examples/matcher.rs
@@ -2,14 +2,21 @@ use elyze::matcher::Match;
 
 struct Hello;
 impl Match<u8> for Hello {
-    fn matcher(&self, data: &[u8]) -> (bool, usize) {
+    fn is_matching(&self, data: &[u8]) -> (bool, usize) {
         let pattern = b"hello";
         (&data[..pattern.len()] == pattern, pattern.len())
+    }
+
+    fn size(&self) -> usize {
+        5
     }
 }
 
 fn main() {
     let hello = Hello;
-    assert_eq!(hello.matcher(b"hello world"), (true, 5));
-    assert_eq!(hello.matcher(b"world is beautiful"), (false, 5));
+    assert_eq!(hello.is_matching(b"hello world"), (true, hello.size()));
+    assert_eq!(
+        hello.is_matching(b"world is beautiful"),
+        (false, hello.size())
+    );
 }

--- a/examples/number.rs
+++ b/examples/number.rs
@@ -1,18 +1,15 @@
 use elyze::bytes::matchers::match_number;
-use elyze::matcher::{Match, MatchSize};
+use elyze::matcher::Match;
 use elyze::recognizer::Recognizable;
 
 struct TokenNumber;
 
 /// Implement the `Match` trait for the token number.
 impl Match<u8> for TokenNumber {
-    fn matcher(&self, data: &[u8]) -> (bool, usize) {
+    fn is_matching(&self, data: &[u8]) -> (bool, usize) {
         match_number(data)
     }
-}
 
-/// Implement the `MatchSize` trait for the token number.
-impl MatchSize for TokenNumber {
     fn size(&self) -> usize {
         0
     }

--- a/examples/operators.rs
+++ b/examples/operators.rs
@@ -1,6 +1,6 @@
 use elyze::bytes::matchers::match_pattern;
 use elyze::errors::{ParseError, ParseResult};
-use elyze::matcher::{Match, MatchSize};
+use elyze::matcher::Match;
 use elyze::recognizer::Recognizer;
 use elyze::scanner::Scanner;
 
@@ -13,15 +13,13 @@ enum OperatorTokens {
 }
 
 impl Match<u8> for OperatorTokens {
-    fn matcher(&self, data: &[u8]) -> (bool, usize) {
+    fn is_matching(&self, data: &[u8]) -> (bool, usize) {
         match self {
             OperatorTokens::Equal => match_pattern(b"==", data),
             OperatorTokens::NotEqual => match_pattern(b"!=", data),
         }
     }
-}
 
-impl MatchSize for OperatorTokens {
     fn size(&self) -> usize {
         match self {
             OperatorTokens::Equal => 2,

--- a/examples/turbofish.rs
+++ b/examples/turbofish.rs
@@ -1,4 +1,4 @@
-use elyze::matcher::{Match, MatchSize};
+use elyze::matcher::Match;
 
 /// Pattern to match.
 const TURBOFISH: [char; 4] = [':', ':', '<', '>'];
@@ -8,7 +8,7 @@ struct Turbofish;
 
 /// Match turbofish operator.
 impl Match<char> for Turbofish {
-    fn matcher(&self, data: &[char]) -> (bool, usize) {
+    fn is_matching(&self, data: &[char]) -> (bool, usize) {
         let pattern = &TURBOFISH;
         if data.len() < pattern.len() {
             return (false, 0);
@@ -18,10 +18,7 @@ impl Match<char> for Turbofish {
         }
         (false, 0)
     }
-}
 
-/// Return the size of the turbofish operator.
-impl MatchSize for Turbofish {
     fn size(&self) -> usize {
         TURBOFISH.len()
     }
@@ -30,11 +27,11 @@ impl MatchSize for Turbofish {
 fn main() {
     let data = [':', ':', '<', '>', 'b'];
     let scanner = elyze::scanner::Scanner::new(&data);
-    let result = Turbofish.matcher(&scanner);
+    let result = Turbofish.is_matching(&scanner);
     println!("{:?}", result); // ( true, 4 ) because the turbofish operator is 4 char
 
     let data = ['a', ':', ':', '<', '>', 'b'];
     let scanner = elyze::scanner::Scanner::new(&data);
-    let result = Turbofish.matcher(&scanner);
+    let result = Turbofish.is_matching(&scanner);
     println!("{:?}", result); // ( false, 0 ) because doesn't match the turbofish operator
 }

--- a/src/bytes/primitives/number.rs
+++ b/src/bytes/primitives/number.rs
@@ -2,7 +2,7 @@
 
 use crate::bytes::matchers::match_number;
 use crate::errors::ParseResult;
-use crate::matcher::{Match, MatchSize};
+use crate::matcher::Match;
 use crate::recognizer::recognize_slice;
 use crate::scanner::Scanner;
 use crate::visitor::Visitor;
@@ -11,13 +11,10 @@ pub struct TokenNumber;
 
 /// Implement the `Match` trait for the token number.
 impl Match<u8> for TokenNumber {
-    fn matcher(&self, data: &[u8]) -> (bool, usize) {
+    fn is_matching(&self, data: &[u8]) -> (bool, usize) {
         match_number(data)
     }
-}
 
-/// Implement the `MatchSize` trait for the token number.
-impl MatchSize for TokenNumber {
     fn size(&self) -> usize {
         0
     }

--- a/src/bytes/primitives/string.rs
+++ b/src/bytes/primitives/string.rs
@@ -2,7 +2,7 @@
 
 use crate::bytes::matchers::match_string;
 use crate::errors::ParseResult;
-use crate::matcher::{Match, MatchSize};
+use crate::matcher::Match;
 use crate::recognizer::recognize_slice;
 use crate::scanner::Scanner;
 use crate::visitor::Visitor;
@@ -11,12 +11,10 @@ use std::borrow::Cow;
 struct TokenString;
 
 impl Match<u8> for TokenString {
-    fn matcher(&self, data: &[u8]) -> (bool, usize) {
+    fn is_matching(&self, data: &[u8]) -> (bool, usize) {
         match_string(data)
     }
-}
 
-impl MatchSize for TokenString {
     fn size(&self) -> usize {
         0
     }

--- a/src/bytes/token.rs
+++ b/src/bytes/token.rs
@@ -1,7 +1,7 @@
 //! Classic tokens
 
 use crate::bytes::matchers::{match_char, match_pattern};
-use crate::matcher::{Match, MatchSize};
+use crate::matcher::Match;
 
 #[derive(Copy, Clone)]
 /// The token type
@@ -76,7 +76,7 @@ pub enum Token {
 }
 
 impl Match<u8> for Token {
-    fn matcher(&self, data: &[u8]) -> (bool, usize) {
+    fn is_matching(&self, data: &[u8]) -> (bool, usize) {
         match self {
             Token::OpenParen => match_char('(', data),
             Token::CloseParen => match_char(')', data),
@@ -113,9 +113,7 @@ impl Match<u8> for Token {
             Token::CrLn => match_pattern(b"\r\n", data),
         }
     }
-}
 
-impl MatchSize for Token {
     fn size(&self) -> usize {
         match self {
             Token::OpenParen => 1,

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -10,11 +10,7 @@ pub trait Match<T> {
     /// # Returns
     /// (true, index) if the data matches the pattern,
     /// (false, index) otherwise
-    fn matcher(&self, data: &[T]) -> (bool, usize);
-}
-
-/// Size of the matchable object.
-pub trait MatchSize {
+    fn is_matching(&self, data: &[T]) -> (bool, usize);
     /// Returns the size of the matchable object.
     fn size(&self) -> usize;
 }

--- a/src/peek.rs
+++ b/src/peek.rs
@@ -4,7 +4,7 @@
 //! `Scanner` without advancing the scanner.
 
 use crate::errors::ParseResult;
-use crate::matcher::MatchSize;
+use crate::matcher::Match;
 use crate::recognizer::Recognizable;
 use crate::scanner::Scanner;
 use std::marker::PhantomData;
@@ -27,8 +27,8 @@ pub struct Peeking<'a, T, S, E> {
 
 impl<'a, T, S, E> Peeking<'a, T, S, E>
 where
-    S: MatchSize,
-    E: MatchSize,
+    S: Match<T>,
+    E: Match<T>,
 {
     /// Get a slice of the data that was peeked.
     pub fn peeked_slice(&self) -> &'a [T] {
@@ -217,7 +217,7 @@ pub struct UntilEnd<T>(PhantomData<T>);
 #[cfg(test)]
 mod tests {
     use crate::bytes::token::Token;
-    use crate::peek::{Until, UntilEnd, peek};
+    use crate::peek::{peek, Until, UntilEnd};
 
     #[test]
     fn test_until() {

--- a/src/recognizer.rs
+++ b/src/recognizer.rs
@@ -1,7 +1,7 @@
 //! Defines how to recognize an object.
 
 use crate::errors::{ParseError, ParseResult};
-use crate::matcher::{Match, MatchSize};
+use crate::matcher::Match;
 use crate::scanner::Scanner;
 
 /// A trait that defines how to recognize an object.
@@ -10,7 +10,7 @@ use crate::scanner::Scanner;
 /// * `V` - The type of the object to recognize
 /// * `T` - The type of the data to scan
 /// * `'a` - The lifetime of the data to scan
-pub trait Recognizable<'a, T, V>: MatchSize {
+pub trait Recognizable<'a, T, V>: Match<T> {
     /// Try to recognize the object for the given scanner.
     ///
     /// # Type Parameters
@@ -102,7 +102,7 @@ pub fn recognize_slice<'a, T, V, R: Recognizable<'a, T, V>>(
 
 /// Recognize an object for the given scanner.
 /// Return the recognized object.
-impl<'a, T, M: Match<T> + MatchSize> Recognizable<'a, T, M> for M {
+impl<'a, T, M: Match<T>> Recognizable<'a, T, M> for M {
     fn recognize(self, scanner: &mut Scanner<'a, T>) -> ParseResult<Option<M>> {
         // Check if the scanner is empty
         if scanner.is_empty() {
@@ -111,7 +111,7 @@ impl<'a, T, M: Match<T> + MatchSize> Recognizable<'a, T, M> for M {
 
         let data = scanner.remaining();
 
-        let (result, size) = self.matcher(data);
+        let (result, size) = self.is_matching(data);
         if !result {
             return Ok(None);
         }
@@ -131,7 +131,7 @@ impl<'a, T, M: Match<T> + MatchSize> Recognizable<'a, T, M> for M {
 
         let data = scanner.remaining();
 
-        let (result, size) = self.matcher(data);
+        let (result, size) = self.is_matching(data);
         if !result {
             return Ok(None);
         }


### PR DESCRIPTION
This PR merges the Match and MatchSize traits in a unified one.

It also rename the "matcher" method into "is_matching" and bump crate version to 1.0.5 even if it's a breaking change