### PR TITLE
Simplify the peeking internal type

### DIFF
--- a/examples/hello_world_acceptance.rs
+++ b/examples/hello_world_acceptance.rs
@@ -1,0 +1,60 @@
+use elyze::errors::ParseResult;
+use elyze::matcher::Match;
+use elyze::recognizer::recognize;
+use elyze::scanner::Scanner;
+use elyze::visitor::Visitor;
+
+struct Hello;
+struct Space;
+struct World;
+
+impl Match<u8> for Hello {
+    fn is_matching(&self, data: &[u8]) -> (bool, usize) {
+        (&data[..5] == b"hello", 5)
+    }
+
+    fn size(&self) -> usize {
+        5
+    }
+}
+
+impl Match<u8> for Space {
+    fn is_matching(&self, data: &[u8]) -> (bool, usize) {
+        (data[0] as char == ' ', 1)
+    }
+
+    fn size(&self) -> usize {
+        1
+    }
+}
+
+impl Match<u8> for World {
+    fn is_matching(&self, data: &[u8]) -> (bool, usize) {
+        (&data[..5] == b"world", 5)
+    }
+
+    fn size(&self) -> usize {
+        5
+    }
+}
+
+// define a structure to implement the `Visitor` trait
+#[derive(Debug)]
+struct HelloWorld;
+
+impl<'a> Visitor<'a, u8> for HelloWorld {
+    fn accept(scanner: &mut Scanner<'a, u8>) -> ParseResult<Self> {
+        recognize(Hello, scanner)?; // recognize the word "hello"
+        recognize(Space, scanner)?; // recognize the space character
+        recognize(World, scanner)?; // recognize the word "world"
+        // return the `HelloWorld` object
+        Ok(HelloWorld)
+    }
+}
+
+fn main() {
+    let data = b"hello world";
+    let mut scanner = elyze::scanner::Scanner::new(data);
+    let result = HelloWorld::accept(&mut scanner);
+    println!("{:?}", result); // Ok(HelloWorld)
+}

--- a/examples/recognizable.rs
+++ b/examples/recognizable.rs
@@ -1,0 +1,36 @@
+use elyze::matcher::Match;
+use elyze::recognizer::Recognizable;
+use elyze::scanner::Scanner;
+
+// define a structure to implement the `Match` trait
+struct UntilFirstSpace;
+
+// implement the `Match` trait
+impl Match<u8> for UntilFirstSpace {
+    fn is_matching(&self, data: &[u8]) -> (bool, usize) {
+        let mut pos = 0;
+        while pos < data.len() && data[pos] != b' ' {
+            pos += 1;
+        }
+        (pos > 0, pos)
+    }
+
+    // The size of the object is unknown
+    fn size(&self) -> usize {
+        0
+    }
+}
+
+fn main() {
+    let mut scanner = Scanner::new(b"hello world");
+    let result = UntilFirstSpace
+        .recognize_slice(&mut scanner)
+        .expect("failed to parse");
+    println!("{:?}", result.map(|s| String::from_utf8_lossy(s))); // Some("hello")
+
+    let mut scanner = Scanner::new(b"loooooooooong string");
+    let result = UntilFirstSpace
+        .recognize_slice(&mut scanner)
+        .expect("failed to parse");
+    println!("{:?}", result.map(|s| String::from_utf8_lossy(s))); // Some("loooooooooong")
+}

--- a/examples/recognize.rs
+++ b/examples/recognize.rs
@@ -1,0 +1,36 @@
+use elyze::matcher::Match;
+use elyze::recognizer::recognize;
+use elyze::scanner::Scanner;
+
+// define a structure to implement the `Match` trait
+#[derive(Debug)]
+struct Hello;
+
+// implement the `Match` trait
+impl Match<u8> for Hello {
+    fn is_matching(&self, data: &[u8]) -> (bool, usize) {
+        // define the pattern to match
+        let pattern = b"hello";
+        // check if the subslice of data matches the pattern
+        (&data[..pattern.len()] == pattern, pattern.len())
+    }
+
+    fn size(&self) -> usize {
+        5
+    }
+}
+
+fn main() {
+    let mut scanner = Scanner::new(b"hello world");
+    let data = recognize(Hello, &mut scanner);
+
+    if let Ok(hello) = data {
+        println!("found: {hello:?}"); // found: "Hello"
+        print!(
+            "remaining: {:?}",
+            String::from_utf8_lossy(scanner.remaining())
+        ); // remaining: " world"
+    } else {
+        println!("not found");
+    }
+}

--- a/examples/recognize2.rs
+++ b/examples/recognize2.rs
@@ -1,0 +1,36 @@
+use elyze::matcher::Match;
+use elyze::recognizer::Recognizable;
+use elyze::scanner::Scanner;
+
+// define a structure to implement the `Match` trait
+#[derive(Debug)]
+struct Hello;
+
+// implement the `Match` trait
+impl Match<u8> for Hello {
+    fn is_matching(&self, data: &[u8]) -> (bool, usize) {
+        // define the pattern to match
+        let pattern = b"hello";
+        // check if the subslice of data matches the pattern
+        (&data[..pattern.len()] == pattern, pattern.len())
+    }
+
+    fn size(&self) -> usize {
+        5
+    }
+}
+
+fn main() {
+    let mut scanner = Scanner::new(b"hello world");
+    let data = Hello.recognize(&mut scanner).expect("failed to parse");
+
+    if let Some(hello) = data {
+        println!("found: {hello:?}"); // found: "Hello"
+        print!(
+            "remaining: {:?}",
+            String::from_utf8_lossy(scanner.remaining())
+        ); // remaining: " world"
+    } else {
+        println!("not found");
+    }
+}

--- a/examples/recognize_slice.rs
+++ b/examples/recognize_slice.rs
@@ -1,0 +1,34 @@
+use elyze::errors::ParseResult;
+use elyze::matcher::Match;
+use elyze::recognizer::recognize_slice;
+use elyze::scanner::Scanner;
+
+// define a structure to implement the `Match` trait
+struct Hello;
+
+// implement the `Match` trait
+impl Match<u8> for Hello {
+    fn is_matching(&self, data: &[u8]) -> (bool, usize) {
+        // define the pattern to match
+        let pattern = b"hello";
+        // check if the subslice of data matches the pattern
+        (&data[..pattern.len()] == pattern, pattern.len())
+    }
+
+    fn size(&self) -> usize {
+        5
+    }
+}
+
+fn main() -> ParseResult<()> {
+    let mut scanner = Scanner::new(b"hello world");
+    let hello_string = recognize_slice(Hello, &mut scanner)?;
+
+    println!("found: {}", String::from_utf8_lossy(hello_string)); // found: "hello"
+    print!(
+        "remaining: {:?}",
+        String::from_utf8_lossy(scanner.remaining())
+    ); // remaining: " world"
+
+    Ok(())
+}

--- a/examples/recognizer.rs
+++ b/examples/recognizer.rs
@@ -1,0 +1,31 @@
+use elyze::matcher::Match;
+use elyze::scanner::Scanner;
+
+// define a structure to implement the `Match` trait
+struct Hello;
+
+// implement the `Match` trait
+impl Match<u8> for Hello {
+    fn is_matching(&self, data: &[u8]) -> (bool, usize) {
+        // define the pattern to match
+        let pattern = b"hello";
+        // check if the subslice of data matches the pattern
+        (&data[..pattern.len()] == pattern, pattern.len())
+    }
+
+    fn size(&self) -> usize {
+        5
+    }
+}
+
+fn main() {
+    let mut scanner = Scanner::new(b"hello world");
+    let (found, size) = Hello.is_matching(scanner.remaining());
+    if !found {
+        println!("not found");
+        return;
+    }
+    let data = &scanner.remaining()[..size];
+    scanner.bump_by(size);
+    println!("found: {:?}", String::from_utf8_lossy(data));
+}

--- a/examples/tokens.rs
+++ b/examples/tokens.rs
@@ -1,0 +1,60 @@
+use elyze::errors::ParseResult;
+use elyze::matcher::Match;
+use elyze::recognizer::recognize;
+
+fn match_char(c: char, data: &[u8]) -> (bool, usize) {
+    match data.first() {
+        Some(&d) => (d == c as u8, 1),
+        None => (false, 0),
+    }
+}
+
+enum Token {
+    Plus,
+    Minus,
+    Star,
+    Slash,
+    LParen,
+    RParen,
+}
+
+impl Match<u8> for Token {
+    fn is_matching(&self, data: &[u8]) -> (bool, usize) {
+        match self {
+            Token::Plus => match_char('+', data),
+            Token::Minus => match_char('-', data),
+            Token::Star => match_char('*', data),
+            Token::Slash => match_char('/', data),
+            Token::LParen => match_char('(', data),
+            Token::RParen => match_char(')', data),
+        }
+    }
+
+    fn size(&self) -> usize {
+        match self {
+            Token::Plus => 1,
+            Token::Minus => 1,
+            Token::Star => 1,
+            Token::Slash => 1,
+            Token::LParen => 1,
+            Token::RParen => 1,
+        }
+    }
+}
+
+fn main() -> ParseResult<()> {
+    let data = b"((+-)*/)end";
+    let mut scanner = elyze::scanner::Scanner::new(data);
+    recognize(Token::LParen, &mut scanner)?;
+    recognize(Token::LParen, &mut scanner)?;
+    recognize(Token::Plus, &mut scanner)?;
+    recognize(Token::Minus, &mut scanner)?;
+    recognize(Token::RParen, &mut scanner)?;
+    recognize(Token::Star, &mut scanner)?;
+    recognize(Token::Slash, &mut scanner)?;
+    recognize(Token::RParen, &mut scanner)?;
+
+    print!("{:?}", String::from_utf8_lossy(scanner.remaining()));
+
+    Ok(())
+}

--- a/src/bytes/components/until_end.rs
+++ b/src/bytes/components/until_end.rs
@@ -1,9 +1,8 @@
-use crate::bytes::token::Token;
 use crate::errors::ParseResult;
 use crate::peek::{PeekResult, Peekable, UntilEnd};
 use crate::scanner::Scanner;
 
-impl<'a> Peekable<'a, u8, Token, Token> for UntilEnd<u8> {
+impl<'a> Peekable<'a, u8> for UntilEnd<u8> {
     /// Peeks at the current position of the `Scanner` until it reaches the end
     /// of the data.
     ///
@@ -15,11 +14,11 @@ impl<'a> Peekable<'a, u8, Token, Token> for UntilEnd<u8> {
     ///
     /// A `PeekResult` where the `end_slice` is the current position of the
     /// `Scanner`, and `start` and `end` are both `()`.
-    fn peek(&self, data: &Scanner<'a, u8>) -> ParseResult<PeekResult<Token, Token>> {
+    fn peek(&self, data: &Scanner<'a, u8>) -> ParseResult<PeekResult> {
         Ok(PeekResult::Found {
             end_slice: data.remaining().len(),
-            start: Token::Whitespace,
-            end: Token::Whitespace,
+            start_element_size: 0,
+            end_element_size: 0,
         })
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,12 +4,16 @@ pub type ParseResult<T> = Result<T, ParseError>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ParseError {
+    /// The parser reached the end of the input
     #[error("Unexpected end of input")]
     UnexpectedEndOfInput,
     #[error("Unexpected token have been encountered")]
+    /// The parser encountered an unexpected token
     UnexpectedToken,
+    /// Unable to decode a string as UTF-8
     #[error("UTF-8 error: {0}")]
     Utf8Error(#[from] std::str::Utf8Error),
+    /// Unable to parse an integer from a string
     #[error("ParseIntError: {0}")]
     ParseIntError(#[from] std::num::ParseIntError),
 }

--- a/src/recognizer.rs
+++ b/src/recognizer.rs
@@ -61,9 +61,6 @@ pub fn recognize<'a, T, V, R: Recognizable<'a, T, V>>(
     recognizable: R,
     scanner: &mut Scanner<'a, T>,
 ) -> ParseResult<V> {
-    if recognizable.size() > scanner.remaining().len() {
-        return Err(ParseError::UnexpectedEndOfInput);
-    }
     recognizable
         .recognize(scanner)?
         .ok_or(ParseError::UnexpectedToken)
@@ -88,13 +85,13 @@ pub fn recognize<'a, T, V, R: Recognizable<'a, T, V>>(
 /// `Err(ParseError::UnexpectedToken)` is returned. If the scanner is at the end
 /// of its input and the recognizable object is longer than the remaining input,
 /// an `Err(ParseError::UnexpectedEndOfInput)` is returned.
-pub fn recognize_slice<'a, T, V, R: Recognizable<'a, T, V>>(
+pub fn recognize_slice<'a, T, V, R>(
     recognizable: R,
     scanner: &mut Scanner<'a, T>,
-) -> ParseResult<&'a [T]> {
-    if recognizable.size() > scanner.remaining().len() {
-        return Err(ParseError::UnexpectedEndOfInput);
-    }
+) -> ParseResult<&'a [T]>
+where
+    R: Recognizable<'a, T, V>,
+{
     recognizable
         .recognize_slice(scanner)?
         .ok_or(ParseError::UnexpectedToken)
@@ -104,8 +101,8 @@ pub fn recognize_slice<'a, T, V, R: Recognizable<'a, T, V>>(
 /// Return the recognized object.
 impl<'a, T, M: Match<T>> Recognizable<'a, T, M> for M {
     fn recognize(self, scanner: &mut Scanner<'a, T>) -> ParseResult<Option<M>> {
-        // Check if the scanner is empty
-        if scanner.is_empty() {
+        // check if the scanner has enough data
+        if self.size() > scanner.remaining().len() {
             return Err(ParseError::UnexpectedEndOfInput);
         }
 


### PR DESCRIPTION
The Peeking<'a, T, S, E> is too convoluated, S and E are Match<T> but it's not needed.

We can simplify it into  Peeking<'a, T>.

Instead of enbedding the Match type we defined the size of the element.