### PR TITLE
Introduce Last peekable

### DIFF
--- a/src/bytes/token.rs
+++ b/src/bytes/token.rs
@@ -3,7 +3,7 @@
 use crate::bytes::matchers::{match_char, match_pattern};
 use crate::errors::{ParseError, ParseResult};
 use crate::matcher::Match;
-use crate::peek;
+use crate::peek::PeekSize;
 use crate::recognizer::Recognizer;
 use crate::scanner::Scanner;
 use crate::visitor::Visitor;
@@ -199,5 +199,12 @@ impl<'a> Visitor<'a, u8> for Token {
             .try_or(Token::CrLn)?
             .finish()
             .ok_or(ParseError::UnexpectedToken)
+    }
+}
+
+/// Implement PeekSize for Token
+impl PeekSize for Token {
+    fn peek_size(&self) -> usize {
+        self.size()
     }
 }


### PR DESCRIPTION
Sometimes data are not clean, for example it can include trailing data.

Like in a list of number "1,2,3,4," the final coma can perturb the parser application.

The Last peekable allow to get the last coma token of the slice, then the user can rid of it